### PR TITLE
Fixed a bug in readRowsBetween

### DIFF
--- a/src/SPIFFSLogger.h
+++ b/src/SPIFFSLogger.h
@@ -166,7 +166,7 @@ size_t SPIFFSLogger<T>::readRowsBetween(SPIFFSLogData<T> *output, time_t fromTim
                 hits++;
                 if (hits > startIdx)
                 {
-                    SPIFFSLogData<T> *curOutput = output + (copied * sizeof(SPIFFSLogData<T>));
+                    SPIFFSLogData<T> *curOutput = output + copied;
 
                     // copy the timestamp
                     memcpy(curOutput, &currentTime, sizeof(time_t));


### PR DESCRIPTION
Hi there - my first pull request on github!
Nice simple library, I like it. There was a bug in readRowsBetween(), curOutput was already SPIFFSLogData<T>* so didn't need the sizeof.
Regards,
Sam